### PR TITLE
Fixes #295

### DIFF
--- a/inversify/inversify.d.ts
+++ b/inversify/inversify.d.ts
@@ -200,6 +200,7 @@ declare namespace inversify {
 
         export interface BindingInSyntax<T> {
             inSingletonScope(): BindingWhenOnSyntax<T>;
+            inTransientScope(): BindingWhenOnSyntax<T>;
         }
 
         export interface BindingInWhenOnSyntax<T> extends BindingInSyntax<T>, BindingWhenOnSyntax<T> {}


### PR DESCRIPTION
Added binding for ```BindingInSyntax<T>.inTransientScope()```

## Description

Adds bindings for method **inTransientScope** added to fix #295

## Related Issue
Fixes [#295](https://github.com/inversify/InversifyJS/issues/295)

## Motivation and Context
Bindings needed for newly implemented methods

## How Has This Been Tested?
``gulp`` script was run

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change requires a change to the type definitions.
- [x] I have updated the type definitions accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
* Add BindingInSyntax<T>.inTransientScope()